### PR TITLE
ignore instance of metric_data

### DIFF
--- a/check_graphite.py
+++ b/check_graphite.py
@@ -264,7 +264,7 @@ if __name__ == '__main__':
                                                                           warning=warn,
                                                                           critical=crit)
     else:
-        if options.empty_ok and isinstance(metric_data, list):
+        if options.empty_ok:
             print 'OK: No output from Graphite for target(s): %s' % ', '.join(targets)
             sys.exit(NAGIOS_STATUSES['OK'])
 


### PR DESCRIPTION
If 'empty_ok' is used, then instance of metric_data should not be used, but rather the 'OK' message should be printed. Or would this functionality be more for a different option, like '--missing-metric-ok'?
